### PR TITLE
Fix link on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Chaos
 #### Visualizations connecting chaos theory, fractals, and  the logistic map!
-###### Written by [Jonny Hyman](www.jonnyhyman.com), 2020
+###### Written by [Jonny Hyman](https://www.jonnyhyman.com), 2020
 
 This code was developed for [this YouTube video from Veritasium](https://www.youtube.com/watch?v=ovJcsL7vyrk)
 


### PR DESCRIPTION
The link to [www.jonnyhyman.com](https://www.jonnyhyman.com) was relative rather than absolute and led to [https://github.com/jonnyhyman/Chaos/blob/master/www.jonnyhyman.com](https://github.com/jonnyhyman/Chaos/blob/master/www.jonnyhyman.com)